### PR TITLE
Fixes proof generation failure for FullExitNFT transactions

### DIFF
--- a/deploy-local.sh
+++ b/deploy-local.sh
@@ -30,7 +30,7 @@ cd ~
 rm -rf ${DEPLOY_PATH}-bak && mv ${DEPLOY_PATH} ${DEPLOY_PATH}-bak
 mkdir -p ${DEPLOY_PATH} && cd ${DEPLOY_PATH}
 git clone --branch develop  https://github.com/bnb-chain/zkbnb-contract.git
-git clone --branch develop https://github.com/bnb-chain/zkbnb-crypto.git
+git clone --branch testnet https://github.com/bnb-chain/zkbnb-crypto.git
 cp -r ${ZkBNB_REPO_PATH} ${DEPLOY_PATH}
 
 

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 )
 
 require (
-	github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221104095956-e2b2f4d4ae4e
+	github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221212101833-9da6da5d4ce9
 	github.com/bnb-chain/zkbnb-eth-rpc v0.0.2
 	github.com/bnb-chain/zkbnb-smt v0.0.2
 	github.com/consensys/gnark v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/bnb-chain/gnark v0.7.1-0.20221031143243-a94d59b60efe/go.mod h1:oQnMur
 github.com/bnb-chain/gnark-crypto v0.7.1-0.20221115030433-6e0195f27b89 h1:z/OVbeX0WlqaD+Rj7OTzJWoyMfpBdT25sSkVL0M1tp0=
 github.com/bnb-chain/gnark-crypto v0.7.1-0.20221115030433-6e0195f27b89/go.mod h1:KPSuJzyxkJA8xZ/+CV47tyqkr9MmpZA3PXivK4VPrVg=
 github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220928090246-9a20106a2347/go.mod h1:L1BEYSG945hwjJCtR5LUQ1pvRmydSsk9oU2d9YvoOrA=
-github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221104095956-e2b2f4d4ae4e h1:uZC86BGCno2OcPL52nmo8BGaIV1MdfTxUlsIuDF6K2c=
-github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221104095956-e2b2f4d4ae4e/go.mod h1:AlzTbvhQojUFpArKHiGHkEYDnapebUbFC/+mek1pZvU=
+github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221212101833-9da6da5d4ce9 h1:XApmerWe6FXael3bH0kW55f7hN2+T2oIntjihOuPBnE=
+github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221212101833-9da6da5d4ce9/go.mod h1:AlzTbvhQojUFpArKHiGHkEYDnapebUbFC/+mek1pZvU=
 github.com/bnb-chain/zkbnb-eth-rpc v0.0.2 h1:1rMa8XpplDNZaxeM1ifXMjSSeH/ucJyLUjHHEw1z4AA=
 github.com/bnb-chain/zkbnb-eth-rpc v0.0.2/go.mod h1:T69T8enicQ5kSRPIzyPJv/jhuvRMz1UxsijPXmlis+I=
 github.com/bnb-chain/zkbnb-go-sdk v1.0.4-0.20221012063144-3a6e84095b4d h1:2+S4/JdKoSPSJr3D7Z5I/Qmv8TkgVYB73vRP0OOunRY=


### PR DESCRIPTION
### Description

Due to the fact that `creatorAccountNameHash` is always a [32-byte long byte array full of 0s](https://github.com/bnb-chain/zkbnb-contract/blob/develop/contracts/AdditionalZkBNB.sol#L267), it causes a proof generation error because of [constraints mismatch](https://github.com/bnb-chain/zkbnb-crypto/blob/develop/circuit/types/fullexit_nft.go#L84).


### Rationale

This PR fixes proof generation problem for FullExitNFT transactions.

### Example

Run FullExitNft integration test and check logs, you will quickly see such line:
```
"caller":"prover/prover.go:32","content":"failed to generate proof, failed to generateProof, err: constraint #68776 is not satisfied: [assertIsEqual] (0 + 0) == (0 + 709952848114681469995946721921909136597142349924028524081942060512670490020)\nr1cs.(*r1cs)
```

### Changes

Notable changes:
* Removed circuit variables equality check:
`IsVariableEqual(api, flag, tx.CreatorAccountIndex, accountsBefore[creatorAccount].AccountIndex)` 

Check: https://github.com/bnb-chain/zkbnb-crypto/pull/71