### PR TITLE
Account asset trees cache

### DIFF
--- a/tree/account_tree.go
+++ b/tree/account_tree.go
@@ -19,6 +19,7 @@ package tree
 
 import (
 	"errors"
+	"fmt"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/poseidon"
 	"hash"
 	"strconv"
@@ -55,6 +56,7 @@ func InitAccountTree(
 
 	// init account state trees
 	accountAssetTrees = NewLazyTreeCache(assetCacheSize, accountNums-1, blockHeight, func(index, block int64) bsmt.SparseMerkleTree {
+		fmt.Printf("NewBASSparseMerkleTree called, index: %d, block: %d\n", index, block)
 		tree, err := bsmt.NewBASSparseMerkleTree(ctx.Hasher(),
 			SetNamespace(ctx, accountAssetNamespace(index)), AssetTreeHeight, NilAccountAssetNodeHash,
 			ctx.Options(block)...)

--- a/tree/account_tree.go
+++ b/tree/account_tree.go
@@ -19,7 +19,6 @@ package tree
 
 import (
 	"errors"
-	"fmt"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/poseidon"
 	"hash"
 	"strconv"
@@ -56,7 +55,6 @@ func InitAccountTree(
 
 	// init account state trees
 	accountAssetTrees = NewLazyTreeCache(assetCacheSize, accountNums-1, blockHeight, func(index, block int64) bsmt.SparseMerkleTree {
-		fmt.Printf("NewBASSparseMerkleTree called, index: %d, block: %d\n", index, block)
 		tree, err := bsmt.NewBASSparseMerkleTree(ctx.Hasher(),
 			SetNamespace(ctx, accountAssetNamespace(index)), AssetTreeHeight, NilAccountAssetNodeHash,
 			ctx.Options(block)...)

--- a/tree/asset_tree_cache.go
+++ b/tree/asset_tree_cache.go
@@ -47,13 +47,14 @@ func (c *AssetTreeCache) GetNextAccountIndex() int64 {
 	return c.nextAccountNumber + 1
 }
 
-// Returns asset tree based on account index
+// Get Returns asset tree based on account index
 func (c *AssetTreeCache) Get(i int64) (tree bsmt.SparseMerkleTree) {
-	c.mainLock.RLock()
-	c.treeCache.ContainsOrAdd(i, c.initFunction(i, c.blockNumber))
-	c.mainLock.RUnlock()
 	if tmpTree, ok := c.treeCache.Get(i); ok {
 		tree = tmpTree.(bsmt.SparseMerkleTree)
+	} else {
+		v := c.initFunction(i, c.blockNumber)
+		c.treeCache.ContainsOrAdd(i, v)
+		tree = v
 	}
 	return
 }


### PR DESCRIPTION
### Description

Fix LRU cache, when get asset from cache, NewSparseMerkleTree is called every time, it's not necessary.
remove unnecessary lock & unlock as well, because LRU cache has its own lock.

### Rationale

![image](https://user-images.githubusercontent.com/2283288/209137495-c1a26bab-facf-40a9-8c0f-cf9c957ace6e.png)
![image](https://user-images.githubusercontent.com/2283288/209137525-9e788c70-b792-4dd8-ad59-0d953ee2f0a8.png)

### Example


### Changes

 