### PR TITLE
Rename NewBASSparseMerkleTree to NewBNBSparseMerkleTree

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 require (
 	github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221222075728-240d4c7279b7
 	github.com/bnb-chain/zkbnb-eth-rpc v0.0.2
-	github.com/bnb-chain/zkbnb-smt v0.0.2
+	github.com/bnb-chain/zkbnb-smt v0.0.3-0.20221222120958-28d12ade0ecb
 	github.com/consensys/gnark v0.7.0
 	github.com/consensys/gnark-crypto v0.7.0
 	github.com/eko/gocache/v2 v2.3.1

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/bnb-chain/zkbnb-eth-rpc v0.0.2 h1:1rMa8XpplDNZaxeM1ifXMjSSeH/ucJyLUjH
 github.com/bnb-chain/zkbnb-eth-rpc v0.0.2/go.mod h1:T69T8enicQ5kSRPIzyPJv/jhuvRMz1UxsijPXmlis+I=
 github.com/bnb-chain/zkbnb-go-sdk v1.0.4-0.20221012063144-3a6e84095b4d h1:2+S4/JdKoSPSJr3D7Z5I/Qmv8TkgVYB73vRP0OOunRY=
 github.com/bnb-chain/zkbnb-go-sdk v1.0.4-0.20221012063144-3a6e84095b4d/go.mod h1:G27Jpl0yB6T/NKXw31bD2B2M91my0PM6SUEpbEGWGL8=
-github.com/bnb-chain/zkbnb-smt v0.0.2 h1:r/iKBTQAVWdpzHVcYEGAkjwpzUiXgaZpegnTjw70JVE=
-github.com/bnb-chain/zkbnb-smt v0.0.2/go.mod h1:QmQTsv2fxBsobFLFZkaiNmr3P0M/mm3W1AiwSU3/cGY=
+github.com/bnb-chain/zkbnb-smt v0.0.3-0.20221222120958-28d12ade0ecb h1:Gx8NG4uwl41JzuPjvDzUz5pLd52asiWcej81jt0V4fc=
+github.com/bnb-chain/zkbnb-smt v0.0.3-0.20221222120958-28d12ade0ecb/go.mod h1:QmQTsv2fxBsobFLFZkaiNmr3P0M/mm3W1AiwSU3/cGY=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d h1:pVrfxiGfwelyab6n21ZBkbkmbevaf+WvMIiR7sr97hw=
 github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=

--- a/tree/account_tree.go
+++ b/tree/account_tree.go
@@ -55,7 +55,7 @@ func InitAccountTree(
 
 	// init account state trees
 	accountAssetTrees = NewLazyTreeCache(assetCacheSize, accountNums-1, blockHeight, func(index, block int64) bsmt.SparseMerkleTree {
-		tree, err := bsmt.NewBASSparseMerkleTree(ctx.Hasher(),
+		tree, err := bsmt.NewBNBSparseMerkleTree(ctx.Hasher(),
 			SetNamespace(ctx, accountAssetNamespace(index)), AssetTreeHeight, NilAccountAssetNodeHash,
 			ctx.Options(block)...)
 		if err != nil {
@@ -64,7 +64,7 @@ func InitAccountTree(
 		}
 		return tree
 	})
-	accountTree, err = bsmt.NewBASSparseMerkleTree(ctx.Hasher(),
+	accountTree, err = bsmt.NewBNBSparseMerkleTree(ctx.Hasher(),
 		SetNamespace(ctx, AccountPrefix), AccountTreeHeight, NilAccountNodeHash,
 		opts...)
 	if err != nil {
@@ -257,6 +257,6 @@ func AccountToNode(
 }
 
 func NewMemAccountAssetTree() (tree bsmt.SparseMerkleTree, err error) {
-	return bsmt.NewBASSparseMerkleTree(bsmt.NewHasherPool(func() hash.Hash { return poseidon.NewPoseidon() }),
+	return bsmt.NewBNBSparseMerkleTree(bsmt.NewHasherPool(func() hash.Hash { return poseidon.NewPoseidon() }),
 		memory.NewMemoryDB(), AssetTreeHeight, NilAccountAssetNodeHash)
 }

--- a/tree/nft_tree.go
+++ b/tree/nft_tree.go
@@ -31,7 +31,7 @@ func InitNftTree(
 ) (
 	nftTree bsmt.SparseMerkleTree, err error,
 ) {
-	nftTree, err = bsmt.NewBASSparseMerkleTree(ctx.Hasher(),
+	nftTree, err = bsmt.NewBNBSparseMerkleTree(ctx.Hasher(),
 		SetNamespace(ctx, NFTPrefix), NftTreeHeight, NilNftNodeHash,
 		ctx.Options(blockHeight)...)
 	if err != nil {


### PR DESCRIPTION
### Description

Rename NewBASSparseMerkleTree to NewBNBSparseMerkleTree

### Rationale

Rebrand only, name change

### Example



### Changes

