### PR TITLE
Update zkbnb-crypto and gnark version to include updated Poseidon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,7 @@ require (
 )
 
 require (
-	github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221222075728-240d4c7279b7
+	github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20230202125012-b89683d3e531
 	github.com/bnb-chain/zkbnb-eth-rpc v0.0.2
 	github.com/bnb-chain/zkbnb-smt v0.0.3-0.20221222120958-28d12ade0ecb
 	github.com/consensys/gnark v0.7.0
@@ -162,8 +162,7 @@ require (
 )
 
 replace (
-	github.com/bnb-chain/zkbnb-crypto => github.com/ruslangm/zkbnb-crypto v0.0.8-0.20230126115155-9458ce8d8a56
 	github.com/bnb-chain/zkbnb-smt => github.com/qct/zkbnb-smt v0.0.0-20230116124655-bad4d92a74f1
-	github.com/consensys/gnark => github.com/ruslangm/gnark v0.7.1-0.20230123144031-9bb6b2aa0443
+	github.com/consensys/gnark => github.com/bnb-chain/gnark v0.7.1-0.20230202123546-e93f0af3da54
 	github.com/consensys/gnark-crypto => github.com/bnb-chain/gnark-crypto v0.7.1-0.20221116021202-8d6fc01ac262
 )

--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,7 @@ require (
 )
 
 require (
-	github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20230202125012-b89683d3e531
+	github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20230203073950-f2baa00f5113
 	github.com/bnb-chain/zkbnb-eth-rpc v0.0.2
 	github.com/bnb-chain/zkbnb-smt v0.0.3-0.20221222120958-28d12ade0ecb
 	github.com/consensys/gnark v0.7.0
@@ -163,6 +163,6 @@ require (
 
 replace (
 	github.com/bnb-chain/zkbnb-smt => github.com/qct/zkbnb-smt v0.0.0-20230116124655-bad4d92a74f1
-	github.com/consensys/gnark => github.com/bnb-chain/gnark v0.7.1-0.20230202123546-e93f0af3da54
+	github.com/consensys/gnark => github.com/bnb-chain/gnark v0.7.1-0.20230203031713-0d81c67d080a
 	github.com/consensys/gnark-crypto => github.com/bnb-chain/gnark-crypto v0.7.1-0.20221116021202-8d6fc01ac262
 )

--- a/go.sum
+++ b/go.sum
@@ -132,13 +132,13 @@ github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwj
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/gnark v0.7.1-0.20230202123546-e93f0af3da54 h1:jlmPW3cB1Xvi1Z5i+icxnTQtweK0HNKFDea6p9Ax1+o=
-github.com/bnb-chain/gnark v0.7.1-0.20230202123546-e93f0af3da54/go.mod h1:dIiKXHFIJARfw+amakfjqOhw6myeLltyU1+RS8/ghl0=
+github.com/bnb-chain/gnark v0.7.1-0.20230203031713-0d81c67d080a h1:qXSqpE4WxfmvxBgFSSNLzl2oYWl5G1xGYkGcPJMpTys=
+github.com/bnb-chain/gnark v0.7.1-0.20230203031713-0d81c67d080a/go.mod h1:dIiKXHFIJARfw+amakfjqOhw6myeLltyU1+RS8/ghl0=
 github.com/bnb-chain/gnark-crypto v0.7.1-0.20221116021202-8d6fc01ac262 h1:kYHgB6keVdBf07XcCFnpvG6rNI40hUWL0Z1JStn62g4=
 github.com/bnb-chain/gnark-crypto v0.7.1-0.20221116021202-8d6fc01ac262/go.mod h1:KPSuJzyxkJA8xZ/+CV47tyqkr9MmpZA3PXivK4VPrVg=
 github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220928090246-9a20106a2347/go.mod h1:L1BEYSG945hwjJCtR5LUQ1pvRmydSsk9oU2d9YvoOrA=
-github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20230202125012-b89683d3e531 h1:lj3f9q5qIZGXbmZPxz2gRWcsQUSS1diFRsPnJUuGYf0=
-github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20230202125012-b89683d3e531/go.mod h1:JauRixokD7VsGRlXGKv9U5xjFc/o2GaRP1IGcYIBLsY=
+github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20230203073950-f2baa00f5113 h1:O4r3PxeX/v+lBYAAp84Nu4m7DhL25JfM4Vhv5BNN34M=
+github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20230203073950-f2baa00f5113/go.mod h1:ysaPHqBDKcjLL37bffxin6tD/XhxE6BfKKXn2Ywuw7A=
 github.com/bnb-chain/zkbnb-eth-rpc v0.0.2 h1:1rMa8XpplDNZaxeM1ifXMjSSeH/ucJyLUjHHEw1z4AA=
 github.com/bnb-chain/zkbnb-eth-rpc v0.0.2/go.mod h1:T69T8enicQ5kSRPIzyPJv/jhuvRMz1UxsijPXmlis+I=
 github.com/bnb-chain/zkbnb-go-sdk v1.0.4-0.20221012063144-3a6e84095b4d h1:2+S4/JdKoSPSJr3D7Z5I/Qmv8TkgVYB73vRP0OOunRY=

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,13 @@ github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwj
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
+github.com/bnb-chain/gnark v0.7.1-0.20230202123546-e93f0af3da54 h1:jlmPW3cB1Xvi1Z5i+icxnTQtweK0HNKFDea6p9Ax1+o=
+github.com/bnb-chain/gnark v0.7.1-0.20230202123546-e93f0af3da54/go.mod h1:dIiKXHFIJARfw+amakfjqOhw6myeLltyU1+RS8/ghl0=
 github.com/bnb-chain/gnark-crypto v0.7.1-0.20221116021202-8d6fc01ac262 h1:kYHgB6keVdBf07XcCFnpvG6rNI40hUWL0Z1JStn62g4=
 github.com/bnb-chain/gnark-crypto v0.7.1-0.20221116021202-8d6fc01ac262/go.mod h1:KPSuJzyxkJA8xZ/+CV47tyqkr9MmpZA3PXivK4VPrVg=
+github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220928090246-9a20106a2347/go.mod h1:L1BEYSG945hwjJCtR5LUQ1pvRmydSsk9oU2d9YvoOrA=
+github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20230202125012-b89683d3e531 h1:lj3f9q5qIZGXbmZPxz2gRWcsQUSS1diFRsPnJUuGYf0=
+github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20230202125012-b89683d3e531/go.mod h1:JauRixokD7VsGRlXGKv9U5xjFc/o2GaRP1IGcYIBLsY=
 github.com/bnb-chain/zkbnb-eth-rpc v0.0.2 h1:1rMa8XpplDNZaxeM1ifXMjSSeH/ucJyLUjHHEw1z4AA=
 github.com/bnb-chain/zkbnb-eth-rpc v0.0.2/go.mod h1:T69T8enicQ5kSRPIzyPJv/jhuvRMz1UxsijPXmlis+I=
 github.com/bnb-chain/zkbnb-go-sdk v1.0.4-0.20221012063144-3a6e84095b4d h1:2+S4/JdKoSPSJr3D7Z5I/Qmv8TkgVYB73vRP0OOunRY=
@@ -283,6 +288,7 @@ github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUork
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fxamacker/cbor/v2 v2.2.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
@@ -896,10 +902,6 @@ github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OK
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
 github.com/rs/zerolog v1.26.1 h1:/ihwxqH+4z8UxyI70wM1z9yCvkWcfz/a3mj48k/Zngc=
 github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+tmc=
-github.com/ruslangm/gnark v0.7.1-0.20230123144031-9bb6b2aa0443 h1:l8JbPL73M05OhDPwuG6sEAcQOY+SOEICRFDm9nl76Uk=
-github.com/ruslangm/gnark v0.7.1-0.20230123144031-9bb6b2aa0443/go.mod h1:dIiKXHFIJARfw+amakfjqOhw6myeLltyU1+RS8/ghl0=
-github.com/ruslangm/zkbnb-crypto v0.0.8-0.20230126115155-9458ce8d8a56 h1:deVEloBxkuQXoUnqVeV1wS3RhZZkqdEEwE9HrP1pu90=
-github.com/ruslangm/zkbnb-crypto v0.0.8-0.20230126115155-9458ce8d8a56/go.mod h1:/q7GtUcGrIIExOGgIlvragixqMqQC4bwkeDuC/3Od1s=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
### Description

Update zkbnb-crypto and gnark version to include updated Poseidon https://github.com/bnb-chain/gnark/pull/14

### Changes

Notable changes:
* updated go.sum and go.mod