### PR TITLE
added support for provers with different block_size to work

### DIFF
--- a/service/prover/prover/prover.go
+++ b/service/prover/prover/prover.go
@@ -163,7 +163,7 @@ func NewProver(c config.Config) (*Prover, error) {
 		prover.SessionNames[i] = c.KeyPath[i]
 	}
 
-	w, err := prover.BlockWitnessModel.GetLatestReceivedBlockWitness()
+	w, err := prover.BlockWitnessModel.GetLatestReceivedBlockWitness(prover.OptionalBlockSizes)
 	var wHeight int64
 	if err != nil {
 		if err == types.DbErrNotFound {
@@ -211,7 +211,7 @@ func (p *Prover) ProveBlock() error {
 		defer lock.Release()
 
 		// Fetch unproved block witness.
-		blockWitness, err := p.BlockWitnessModel.GetLatestBlockWitness()
+		blockWitness, err := p.BlockWitnessModel.GetLatestBlockWitness(p.OptionalBlockSizes)
 		if err != nil {
 			return nil, err
 		}

--- a/service/witness/witness/witness.go
+++ b/service/witness/witness/witness.go
@@ -381,6 +381,7 @@ func (w *Witness) constructBlockWitness(block *block.Block, latestVerifiedBlockN
 	blockWitness := blockwitness.BlockWitness{
 		Height:      block.BlockHeight,
 		WitnessData: string(bz),
+		BlockSize:   block.BlockSize,
 		Status:      blockwitness.StatusPublished,
 	}
 	return &blockWitness, nil


### PR DESCRIPTION
### Description

Now provers can be deployed separately with different block sizes

### Changes

Notable changes:
* added column `block_size` in witness
* added support for prover side to fetch only block with configured block size