### PR TITLE
Modifies context logging

### DIFF
--- a/common/log/util.go
+++ b/common/log/util.go
@@ -16,11 +16,13 @@ const (
 
 func UpdateCtxWithKV(ctx context.Context, keyValues ...interface{}) context.Context {
 	if len(keyValues)%2 != 0 {
-		logx.Error("UpdateCtxWithKV: odd number of arguments, context won't be updated")
 		return ctx
 	}
 	for i := 0; i < len(keyValues); i += 2 {
-		ctx = logx.ContextWithFields(ctx, logx.Field(keyValues[i].(string), keyValues[i+1]))
+		key, ok := keyValues[i].(string)
+		if ok {
+			ctx = logx.ContextWithFields(ctx, logx.Field(key, keyValues[i+1]))
+		}
 	}
 	return ctx
 }
@@ -28,11 +30,13 @@ func UpdateCtxWithKV(ctx context.Context, keyValues ...interface{}) context.Cont
 func NewCtxWithKV(keyValues ...interface{}) context.Context {
 	ctx := context.Background()
 	if len(keyValues)%2 != 0 {
-		logx.Error("NewCtxWithKV: odd number of arguments, context won't be updated")
 		return ctx
 	}
 	for i := 0; i < len(keyValues); i += 2 {
-		ctx = logx.ContextWithFields(ctx, logx.Field(keyValues[i].(string), keyValues[i+1]))
+		key, ok := keyValues[i].(string)
+		if ok {
+			ctx = logx.ContextWithFields(ctx, logx.Field(key, keyValues[i+1]))
+		}
 	}
 	return ctx
 }

--- a/tree/account_tree.go
+++ b/tree/account_tree.go
@@ -56,7 +56,7 @@ func InitAccountTree(
 	accountTree bsmt.SparseMerkleTree, accountAssetTrees *AssetTreeCache, err error,
 ) {
 	var maxAccountIndex int64
-	ctxLog := log.NewCtxWithKV(ctx, log.BlockHeightContext, blockHeight)
+	ctxLog := log.NewCtxWithKV(log.BlockHeightContext, blockHeight)
 	if fromHistory {
 		maxAccountIndex, err = accountHistoryModel.GetMaxAccountIndex(blockHeight)
 		if err != nil && err != types.DbErrNotFound {


### PR DESCRIPTION
### Description

Fixes context usage in account_tree.go, removes unnecessary error logging and avoids panic if context key cannot be casted to string 
