### PR TITLE
fix parse error in desert_verifier_parse.py

### DIFF
--- a/service/prover/desert_verifier_parse.py
+++ b/service/prover/desert_verifier_parse.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
 
     vks = []
     ics = []
-    with open(src_filename[i], "r") as f:
+    with open(src_filename, "r") as f:
         lines = f.readlines()
         for nu in range(len(lines)):
             s = lines[nu]


### PR DESCRIPTION
### Description

fix parse error in desert_verifier_parse.py

### example
run the command to update vks in DesertVerifier.sol
```shell
python3 desert_verifier_parse.py ~/bnb/zkbnb-crypto/circuit/solidity/ZkBNBVerifier1.sol ~/bnb/zkbnb-contract/contracts/DesertVerifier.sol
```